### PR TITLE
Print regular hours and break duration in status command.

### DIFF
--- a/src/client/time_entries.rs
+++ b/src/client/time_entries.rs
@@ -92,6 +92,8 @@ pub struct TimeEntry {
     pub breaks: Vec<TimeEntryBreak>,
     #[serde(rename = "regularHours", deserialize_with = "f32_from_str")]
     pub regular_hours: f32,
+    #[serde(rename = "duration", deserialize_with = "f32_from_str")]
+    pub duration: f32,
     // pub timezone: String,
 }
 

--- a/src/commands/live.rs
+++ b/src/commands/live.rs
@@ -17,6 +17,14 @@ pub fn status() -> Result<String> {
             let breaks_in_seconds = total_duration_in_seconds - regular_hours_in_seconds;
             let breaks_formatted = format_seconds_as_human_readable(breaks_in_seconds);
 
+            // If on break, print the break start time
+            if let Some(br) = entry.current_break() {
+                msg.push_str(&format!(
+                    ", started break at {}",
+                    local_time_format(br.start_time)
+                ));
+            }
+
             // Print regular hours and breaks
             msg.push_str(&format!(
                 " (Regular hours: {}, Breaks: {})",


### PR DESCRIPTION
### Clocked in, not in a break
```
$ rippling-cli status
Clocked in since 19:57 (Regular hours: 00h 01m, Breaks: 01h 47m)
```
(I took a long break)

### Clocked in, in a break
```
$ rippling-cli status
Clocked in since 19:57, started break at 21:46 (Regular hours: 00h 02m, Breaks: 01h 47m)
```